### PR TITLE
Add BFS and DFS grid visualizer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,10 @@
+import GridVisualizer from '../components/GridVisualizer';
 
 export default function Home() {
   return (
-    <div>
-      <h1>Welcome to the visualizer</h1>
-    </div>
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">BFS & DFS Visualizer</h1>
+      <GridVisualizer />
+    </main>
   );
 }

--- a/components/GridVisualizer.tsx
+++ b/components/GridVisualizer.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import { bfs, dfs, Coord } from '../lib/algorithms';
+
+const SIZE = 5;
+
+export default function GridVisualizer() {
+  const [visited, setVisited] = useState<Coord[]>([]);
+  const [running, setRunning] = useState(false);
+
+  const run = (type: 'bfs' | 'dfs') => {
+    const order = type === 'bfs' ? bfs(SIZE, SIZE, [0, 0]) : dfs(SIZE, SIZE, [0, 0]);
+    setVisited([]);
+    setRunning(true);
+    let i = 0;
+    const interval = setInterval(() => {
+      setVisited((prev) => [...prev, order[i]]);
+      i++;
+      if (i >= order.length) {
+        clearInterval(interval);
+        setRunning(false);
+      }
+    }, 300);
+  };
+
+  const isVisited = (r: number, c: number) =>
+    visited.some(([vr, vc]) => vr === r && vc === c);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <button
+          className="px-3 py-1 bg-blue-500 text-white rounded disabled:opacity-50"
+          onClick={() => run('bfs')}
+          disabled={running}
+        >
+          BFS
+        </button>
+        <button
+          className="px-3 py-1 bg-green-500 text-white rounded disabled:opacity-50"
+          onClick={() => run('dfs')}
+          disabled={running}
+        >
+          DFS
+        </button>
+      </div>
+      <div className="grid grid-cols-5 gap-1">
+        {Array.from({ length: SIZE }).map((_, r) =>
+          Array.from({ length: SIZE }).map((__, c) => (
+            <div
+              key={`${r}-${c}`}
+              className={`h-10 w-10 border ${isVisited(r, c) ? 'bg-yellow-300' : 'bg-white'}`}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/algorithms.ts
+++ b/lib/algorithms.ts
@@ -1,0 +1,51 @@
+export type Coord = [number, number];
+
+const directions: Coord[] = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+export function bfs(rows: number, cols: number, start: Coord): Coord[] {
+  const visited: boolean[][] = Array.from({ length: rows }, () =>
+    Array(cols).fill(false)
+  );
+  const order: Coord[] = [];
+  const queue: Coord[] = [start];
+  visited[start[0]][start[1]] = true;
+
+  while (queue.length) {
+    const [r, c] = queue.shift()!;
+    order.push([r, c]);
+    for (const [dr, dc] of directions) {
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && !visited[nr][nc]) {
+        visited[nr][nc] = true;
+        queue.push([nr, nc]);
+      }
+    }
+  }
+
+  return order;
+}
+
+export function dfs(rows: number, cols: number, start: Coord): Coord[] {
+  const visited: boolean[][] = Array.from({ length: rows }, () =>
+    Array(cols).fill(false)
+  );
+  const order: Coord[] = [];
+
+  function walk(r: number, c: number) {
+    if (r < 0 || r >= rows || c < 0 || c >= cols || visited[r][c]) return;
+    visited[r][c] = true;
+    order.push([r, c]);
+    for (const [dr, dc] of directions) {
+      walk(r + dr, c + dc);
+    }
+  }
+
+  walk(start[0], start[1]);
+  return order;
+}


### PR DESCRIPTION
## Summary
- Implement BFS and DFS algorithms
- Create grid component to animate BFS/DFS traversals
- Display BFS & DFS visualizer on home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build` *(fails: failed to fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6898b287492c8321a202490b17531b75