### PR TITLE
Fix grid layout spacing for visualizer

### DIFF
--- a/components/GridVisualizer.tsx
+++ b/components/GridVisualizer.tsx
@@ -45,7 +45,7 @@ export default function GridVisualizer() {
           DFS
         </button>
       </div>
-      <div className="grid grid-cols-5 gap-1">
+      <div className="grid grid-cols-5 gap-1 w-fit">
         {Array.from({ length: SIZE }).map((_, r) =>
           Array.from({ length: SIZE }).map((__, c) => (
             <div


### PR DESCRIPTION
## Summary
- ensure grid fits content to prevent wide column spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires configuration)*
- `npm run build` *(fails: failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6898b8d6c85c83218ace0ecebc9d95f1