### PR TITLE
Stop traversal after reaching end node and show start/end on grid

### DIFF
--- a/components/GridVisualizer.tsx
+++ b/components/GridVisualizer.tsx
@@ -4,28 +4,36 @@ import { useState } from 'react';
 import { bfs, dfs, Coord } from '../lib/algorithms';
 
 const SIZE = 5;
+const START: Coord = [0, 0];
+const END: Coord = [SIZE - 1, SIZE - 1];
 
 export default function GridVisualizer() {
   const [visited, setVisited] = useState<Coord[]>([]);
   const [running, setRunning] = useState(false);
 
   const run = (type: 'bfs' | 'dfs') => {
-    const order = type === 'bfs' ? bfs(SIZE, SIZE, [0, 0]) : dfs(SIZE, SIZE, [0, 0]);
+    const order =
+      type === 'bfs'
+        ? bfs(SIZE, SIZE, START, END)
+        : dfs(SIZE, SIZE, START, END);
     setVisited([]);
     setRunning(true);
     let i = 0;
     const interval = setInterval(() => {
-      setVisited((prev) => [...prev, order[i]]);
-      i++;
       if (i >= order.length) {
         clearInterval(interval);
         setRunning(false);
+        return;
       }
+      setVisited((prev) => [...prev, order[i]]);
+      i++;
     }, 300);
   };
 
   const isVisited = (r: number, c: number) =>
     visited.some(([vr, vc]) => vr === r && vc === c);
+  const isStart = (r: number, c: number) => r === START[0] && c === START[1];
+  const isEnd = (r: number, c: number) => r === END[0] && c === END[1];
 
   return (
     <div className="space-y-4">
@@ -50,7 +58,15 @@ export default function GridVisualizer() {
           Array.from({ length: SIZE }).map((__, c) => (
             <div
               key={`${r}-${c}`}
-              className={`h-10 w-10 border ${isVisited(r, c) ? 'bg-yellow-300' : 'bg-white'}`}
+              className={`h-10 w-10 border ${
+                isStart(r, c)
+                  ? 'bg-green-300'
+                  : isEnd(r, c)
+                  ? 'bg-red-300'
+                  : isVisited(r, c)
+                  ? 'bg-yellow-300'
+                  : 'bg-white'
+              }`}
             />
           ))
         )}

--- a/lib/algorithms.ts
+++ b/lib/algorithms.ts
@@ -7,7 +7,12 @@ const directions: Coord[] = [
   [0, -1],
 ];
 
-export function bfs(rows: number, cols: number, start: Coord): Coord[] {
+export function bfs(
+  rows: number,
+  cols: number,
+  start: Coord,
+  end: Coord
+): Coord[] {
   const visited: boolean[][] = Array.from({ length: rows }, () =>
     Array(cols).fill(false)
   );
@@ -18,6 +23,7 @@ export function bfs(rows: number, cols: number, start: Coord): Coord[] {
   while (queue.length) {
     const [r, c] = queue.shift()!;
     order.push([r, c]);
+    if (r === end[0] && c === end[1]) break;
     for (const [dr, dc] of directions) {
       const nr = r + dr;
       const nc = c + dc;
@@ -31,16 +37,27 @@ export function bfs(rows: number, cols: number, start: Coord): Coord[] {
   return order;
 }
 
-export function dfs(rows: number, cols: number, start: Coord): Coord[] {
+export function dfs(
+  rows: number,
+  cols: number,
+  start: Coord,
+  end: Coord
+): Coord[] {
   const visited: boolean[][] = Array.from({ length: rows }, () =>
     Array(cols).fill(false)
   );
   const order: Coord[] = [];
+  let found = false;
 
   function walk(r: number, c: number) {
+    if (found) return;
     if (r < 0 || r >= rows || c < 0 || c >= cols || visited[r][c]) return;
     visited[r][c] = true;
     order.push([r, c]);
+    if (r === end[0] && c === end[1]) {
+      found = true;
+      return;
+    }
     for (const [dr, dc] of directions) {
       walk(r + dr, c + dc);
     }


### PR DESCRIPTION
## Summary
- highlight start (green) and end (red) cells in the grid visualizer
- stop BFS/DFS traversal when the end node is reached and guard against overrun

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898c624b98083218de847cb98c1822b