### PR TITLE
Visualize path and enlarge grid

### DIFF
--- a/components/GridVisualizer.tsx
+++ b/components/GridVisualizer.tsx
@@ -3,26 +3,29 @@
 import { useState } from 'react';
 import { bfs, dfs, Coord } from '../lib/algorithms';
 
-const SIZE = 5;
+const SIZE = 10;
 const START: Coord = [0, 0];
 const END: Coord = [SIZE - 1, SIZE - 1];
 
 export default function GridVisualizer() {
   const [visited, setVisited] = useState<Coord[]>([]);
+  const [path, setPath] = useState<Coord[]>([]);
   const [running, setRunning] = useState(false);
 
   const run = (type: 'bfs' | 'dfs') => {
-    const order =
+    const { order, path: resultPath } =
       type === 'bfs'
         ? bfs(SIZE, SIZE, START, END)
         : dfs(SIZE, SIZE, START, END);
     setVisited([]);
+    setPath([]);
     setRunning(true);
     let i = 0;
     const interval = setInterval(() => {
       if (i >= order.length) {
         clearInterval(interval);
         setRunning(false);
+        setPath(resultPath);
         return;
       }
       setVisited((prev) => [...prev, order[i]]);
@@ -32,6 +35,8 @@ export default function GridVisualizer() {
 
   const isVisited = (r: number, c: number) =>
     visited.some(([vr, vc]) => vr === r && vc === c);
+  const isPath = (r: number, c: number) =>
+    path.some(([pr, pc]) => pr === r && pc === c);
   const isStart = (r: number, c: number) => r === START[0] && c === START[1];
   const isEnd = (r: number, c: number) => r === END[0] && c === END[1];
 
@@ -53,7 +58,7 @@ export default function GridVisualizer() {
           DFS
         </button>
       </div>
-      <div className="grid grid-cols-5 gap-1 w-fit">
+      <div className="grid grid-cols-10 gap-1 w-fit">
         {Array.from({ length: SIZE }).map((_, r) =>
           Array.from({ length: SIZE }).map((__, c) => (
             <div
@@ -63,6 +68,8 @@ export default function GridVisualizer() {
                   ? 'bg-green-300'
                   : isEnd(r, c)
                   ? 'bg-red-300'
+                  : isPath(r, c)
+                  ? 'bg-blue-300'
                   : isVisited(r, c)
                   ? 'bg-yellow-300'
                   : 'bg-white'

--- a/lib/algorithms.ts
+++ b/lib/algorithms.ts
@@ -7,34 +7,58 @@ const directions: Coord[] = [
   [0, -1],
 ];
 
+export interface SearchResult {
+  order: Coord[];
+  path: Coord[];
+}
+
 export function bfs(
   rows: number,
   cols: number,
   start: Coord,
   end: Coord
-): Coord[] {
+): SearchResult {
   const visited: boolean[][] = Array.from({ length: rows }, () =>
     Array(cols).fill(false)
   );
+  const prev: (Coord | null)[][] = Array.from({ length: rows }, () =>
+    Array(cols).fill(null)
+  );
   const order: Coord[] = [];
   const queue: Coord[] = [start];
+  let found = false;
   visited[start[0]][start[1]] = true;
 
   while (queue.length) {
     const [r, c] = queue.shift()!;
     order.push([r, c]);
-    if (r === end[0] && c === end[1]) break;
+    if (r === end[0] && c === end[1]) {
+      found = true;
+      break;
+    }
     for (const [dr, dc] of directions) {
       const nr = r + dr;
       const nc = c + dc;
       if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && !visited[nr][nc]) {
         visited[nr][nc] = true;
+        prev[nr][nc] = [r, c];
         queue.push([nr, nc]);
       }
     }
   }
 
-  return order;
+  const path: Coord[] = [];
+  if (found) {
+    let curr: Coord | null = end;
+    while (curr) {
+      path.push(curr);
+      const p = prev[curr[0]][curr[1]];
+      curr = p;
+    }
+    path.reverse();
+  }
+
+  return { order, path };
 }
 
 export function dfs(
@@ -42,27 +66,27 @@ export function dfs(
   cols: number,
   start: Coord,
   end: Coord
-): Coord[] {
+): SearchResult {
   const visited: boolean[][] = Array.from({ length: rows }, () =>
     Array(cols).fill(false)
   );
   const order: Coord[] = [];
-  let found = false;
+  const path: Coord[] = [];
 
-  function walk(r: number, c: number) {
-    if (found) return;
-    if (r < 0 || r >= rows || c < 0 || c >= cols || visited[r][c]) return;
+  function walk(r: number, c: number): boolean {
+    if (r < 0 || r >= rows || c < 0 || c >= cols || visited[r][c])
+      return false;
     visited[r][c] = true;
     order.push([r, c]);
-    if (r === end[0] && c === end[1]) {
-      found = true;
-      return;
-    }
+    path.push([r, c]);
+    if (r === end[0] && c === end[1]) return true;
     for (const [dr, dc] of directions) {
-      walk(r + dr, c + dc);
+      if (walk(r + dr, c + dc)) return true;
     }
+    path.pop();
+    return false;
   }
 
   walk(start[0], start[1]);
-  return order;
+  return { order, path };
 }


### PR DESCRIPTION
## Summary
- Show BFS/DFS final path with blue cells after search completion
- Increase grid size to 10x10 for a larger visual display
- Track parent nodes in BFS/DFS to reconstruct the path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb0c2bec8321a7321e71d699a50d