### PR TITLE
Add grid controls, random walls, and centered layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-100`}
       >
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,8 @@ import GridVisualizer from '../components/GridVisualizer';
 
 export default function Home() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-bold mb-4">BFS & DFS Visualizer</h1>
+    <main className="p-8 flex flex-col items-center space-y-4">
+      <h1 className="text-3xl font-bold">BFS & DFS Visualizer</h1>
       <GridVisualizer />
     </main>
   );

--- a/components/GridVisualizer.tsx
+++ b/components/GridVisualizer.tsx
@@ -1,22 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, ChangeEvent } from 'react';
 import { bfs, dfs, Coord } from '../lib/algorithms';
 
-const SIZE = 10;
 const START: Coord = [0, 0];
-const END: Coord = [SIZE - 1, SIZE - 1];
 
 export default function GridVisualizer() {
+  const [rows, setRows] = useState(10);
+  const [cols, setCols] = useState(10);
+  const [speed, setSpeed] = useState(300);
+  const [walls, setWalls] = useState<Set<string>>(new Set());
   const [visited, setVisited] = useState<Coord[]>([]);
   const [path, setPath] = useState<Coord[]>([]);
   const [running, setRunning] = useState(false);
 
+  const end: Coord = [rows - 1, cols - 1];
+
   const run = (type: 'bfs' | 'dfs') => {
     const { order, path: resultPath } =
       type === 'bfs'
-        ? bfs(SIZE, SIZE, START, END)
-        : dfs(SIZE, SIZE, START, END);
+        ? bfs(rows, cols, START, end, walls)
+        : dfs(rows, cols, START, end, walls);
     setVisited([]);
     setPath([]);
     setRunning(true);
@@ -30,7 +34,21 @@ export default function GridVisualizer() {
       }
       setVisited((prev) => [...prev, order[i]]);
       i++;
-    }, 300);
+    }, speed);
+  };
+
+  const addRandomWalls = () => {
+    const newWalls = new Set<string>();
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        if ((r === START[0] && c === START[1]) || (r === end[0] && c === end[1]))
+          continue;
+        if (Math.random() < 0.3) newWalls.add(`${r},${c}`);
+      }
+    }
+    setWalls(newWalls);
+    setVisited([]);
+    setPath([]);
   };
 
   const isVisited = (r: number, c: number) =>
@@ -38,11 +56,28 @@ export default function GridVisualizer() {
   const isPath = (r: number, c: number) =>
     path.some(([pr, pc]) => pr === r && pc === c);
   const isStart = (r: number, c: number) => r === START[0] && c === START[1];
-  const isEnd = (r: number, c: number) => r === END[0] && c === END[1];
+  const isEnd = (r: number, c: number) => r === end[0] && c === end[1];
+  const isWall = (r: number, c: number) => walls.has(`${r},${c}`);
+
+  const handleChangeRows = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(e.target.value) || 1;
+    setRows(val);
+    setVisited([]);
+    setPath([]);
+    setWalls(new Set());
+  };
+
+  const handleChangeCols = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(e.target.value) || 1;
+    setCols(val);
+    setVisited([]);
+    setPath([]);
+    setWalls(new Set());
+  };
 
   return (
-    <div className="space-y-4">
-      <div className="flex space-x-2">
+    <div className="flex flex-col items-center space-y-4">
+      <div className="bg-white p-4 rounded shadow flex flex-wrap items-center gap-2 justify-center">
         <button
           className="px-3 py-1 bg-blue-500 text-white rounded disabled:opacity-50"
           onClick={() => run('bfs')}
@@ -57,10 +92,56 @@ export default function GridVisualizer() {
         >
           DFS
         </button>
+        <label className="flex items-center space-x-1">
+          <span className="text-sm">Rows</span>
+          <input
+            type="number"
+            min={2}
+            value={rows}
+            onChange={handleChangeRows}
+            className="w-16 border rounded px-1 py-0.5"
+            disabled={running}
+          />
+        </label>
+        <label className="flex items-center space-x-1">
+          <span className="text-sm">Cols</span>
+          <input
+            type="number"
+            min={2}
+            value={cols}
+            onChange={handleChangeCols}
+            className="w-16 border rounded px-1 py-0.5"
+            disabled={running}
+          />
+        </label>
+        <label className="flex items-center space-x-1">
+          <span className="text-sm">Speed</span>
+          <select
+            value={speed}
+            onChange={(e) => setSpeed(parseInt(e.target.value))}
+            className="border rounded px-1 py-0.5"
+            disabled={running}
+          >
+            <option value={100}>Fast</option>
+            <option value={300}>Medium</option>
+            <option value={500}>Slow</option>
+          </select>
+        </label>
+        <button
+          className="px-3 py-1 bg-gray-700 text-white rounded disabled:opacity-50"
+          onClick={addRandomWalls}
+          disabled={running}
+        >
+          Random Walls
+        </button>
       </div>
-      <div className="grid grid-cols-10 gap-1 w-fit">
-        {Array.from({ length: SIZE }).map((_, r) =>
-          Array.from({ length: SIZE }).map((__, c) => (
+
+      <div
+        className={`grid gap-1 w-fit`}
+        style={{ gridTemplateColumns: `repeat(${cols}, 2.5rem)` }}
+      >
+        {Array.from({ length: rows }).map((_, r) =>
+          Array.from({ length: cols }).map((__, c) => (
             <div
               key={`${r}-${c}`}
               className={`h-10 w-10 border ${
@@ -68,6 +149,8 @@ export default function GridVisualizer() {
                   ? 'bg-green-300'
                   : isEnd(r, c)
                   ? 'bg-red-300'
+                  : isWall(r, c)
+                  ? 'bg-gray-500'
                   : isPath(r, c)
                   ? 'bg-blue-300'
                   : isVisited(r, c)
@@ -81,3 +164,4 @@ export default function GridVisualizer() {
     </div>
   );
 }
+

--- a/lib/algorithms.ts
+++ b/lib/algorithms.ts
@@ -16,7 +16,8 @@ export function bfs(
   rows: number,
   cols: number,
   start: Coord,
-  end: Coord
+  end: Coord,
+  walls: Set<string> = new Set()
 ): SearchResult {
   const visited: boolean[][] = Array.from({ length: rows }, () =>
     Array(cols).fill(false)
@@ -39,7 +40,14 @@ export function bfs(
     for (const [dr, dc] of directions) {
       const nr = r + dr;
       const nc = c + dc;
-      if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && !visited[nr][nc]) {
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        !visited[nr][nc] &&
+        !walls.has(`${nr},${nc}`)
+      ) {
         visited[nr][nc] = true;
         prev[nr][nc] = [r, c];
         queue.push([nr, nc]);
@@ -65,7 +73,8 @@ export function dfs(
   rows: number,
   cols: number,
   start: Coord,
-  end: Coord
+  end: Coord,
+  walls: Set<string> = new Set()
 ): SearchResult {
   const visited: boolean[][] = Array.from({ length: rows }, () =>
     Array(cols).fill(false)
@@ -74,7 +83,14 @@ export function dfs(
   const path: Coord[] = [];
 
   function walk(r: number, c: number): boolean {
-    if (r < 0 || r >= rows || c < 0 || c >= cols || visited[r][c])
+    if (
+      r < 0 ||
+      r >= rows ||
+      c < 0 ||
+      c >= cols ||
+      visited[r][c] ||
+      walls.has(`${r},${c}`)
+    )
       return false;
     visited[r][c] = true;
     order.push([r, c]);


### PR DESCRIPTION
## Summary
- add configurable rows, columns, speed, and random walls in a top control card
- support wall barriers in BFS and DFS algorithms
- center grid and update page styling with subtle background

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)
- `npm run build` (fails: unable to fetch fonts)

------
https://chatgpt.com/codex/tasks/task_e_6898ce6a82808321a5f931f4326ecc89